### PR TITLE
Fix youtube.com to www.youtube.com redirect

### DIFF
--- a/src/TrendingRequester.js
+++ b/src/TrendingRequester.js
@@ -1,5 +1,5 @@
 const axios = require("axios")
-const trendingPageBase = "https://youtube.com/feed/trending"
+const trendingPageBase = "https://www.youtube.com/feed/trending"
 const pageAdditions = {
     'music': '4gINGgt5dG1hX2NoYXJ0cw%3D%3D',
     'gaming': '4gIcGhpnYW1pbmdfY29ycHVzX21vc3RfcG9wdWxhcg%3D%3D',


### PR DESCRIPTION
This pull request changes the youtube domain in the requests to save a redirect, as YouTube redirects youtube.com to www.youtube.com. This is purely a performance improvement and doesn't impact the functionality in any way.